### PR TITLE
docs(cap sample): Fix policy config

### DIFF
--- a/ams-cap-sample/README.md
+++ b/ams-cap-sample/README.md
@@ -197,13 +197,12 @@ mock.users:
         attributes:
           businessPartner:
             - "10401010"
-          policies: 
-          	- "cap.Admin"
+        policies: 
+          - "cap.Admin"
       user:
         password: user
-        attributes:
-          policies:
-          	- "local.MysteryAdmin"
+        policies:
+          - "local.MysteryAdmin"
 ```
 
 Put the policies in the `local` package to simulate admin policies for testing. This package is ignored during the


### PR DESCRIPTION
It seems that the AMS CAP plugin in version 2.7.0 does not look up `policies` in `attributes`.  It works if I put `policies` one level higher.