### PR TITLE
Lib version 4.3.0

### DIFF
--- a/ams-cap-bookshop/pom.xml
+++ b/ams-cap-bookshop/pom.xml
@@ -21,7 +21,7 @@
 
         <cds.install-node.downloadUrl>https://nodejs.org/dist/</cds.install-node.downloadUrl>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <sap.cloud.security.ams.version>4.2.1</sap.cloud.security.ams.version>
+        <sap.cloud.security.ams.version>4.3.0</sap.cloud.security.ams.version>
         <sap.cloud.security.ams.dcl-compiler.version>1.4.0</sap.cloud.security.ams.dcl-compiler.version>
         <sap.cloud.security.version>4.0.7</sap.cloud.security.version>
     </properties>

--- a/ams-cap-bookshop/srv/pom.xml
+++ b/ams-cap-bookshop/srv/pom.xml
@@ -76,7 +76,6 @@
         <dependency>
             <groupId>com.sap.cloud.security.ams</groupId>
             <artifactId>spring-boot-starter-cap-ams-test</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/ams-cap-bookshop/srv/src/test/resources/application-test.yml
+++ b/ams-cap-bookshop/srv/src/test/resources/application-test.yml
@@ -3,6 +3,7 @@ spring:
   sql:
     init:
       platform: h2
+sap.ams.test.enabled: true
 logging.level:
   com.sap.cds.security.authorization: TRACE
   com.sap.cloud.security.ams: TRACE

--- a/ams-spring-boot-shopping/src/main/java/com/sap/cloud/security/ams/samples/config/SecurityConfiguration.java
+++ b/ams-spring-boot-shopping/src/main/java/com/sap/cloud/security/ams/samples/config/SecurityConfiguration.java
@@ -11,6 +11,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
+import static com.sap.cloud.security.ams.samples.config.Privileges.*;
 import static org.springframework.http.HttpMethod.*;
 
 /**
@@ -29,7 +30,7 @@ import static org.springframework.http.HttpMethod.*;
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
-@PropertySource(factory = IdentityServicesPropertySourceFactory.class, ignoreResourceNotFound = true, value = { "" })
+@PropertySource(factory = IdentityServicesPropertySourceFactory.class, ignoreResourceNotFound = true, value = {""})
 public class SecurityConfiguration {
 
     @Bean
@@ -41,17 +42,19 @@ public class SecurityConfiguration {
                     // Authenticated endpoints without authorization checks
                     authz.requestMatchers(GET, "/privileges").authenticated();
 
-                    // Endpoints protected with AMS  method-level security
+                    // CHOOSE ONE idiom below (route-level authorization + service-level filtering vs. full service-level authorization
+
+                    // Idiom 1 (Full service-level authorization): these endpoints are protected with AMS method-level security
                     authz.requestMatchers(GET, "/products").authenticated();
                     authz.requestMatchers(GET, "/orders").authenticated();
                     authz.requestMatchers(POST, "/orders").authenticated();
                     authz.requestMatchers(DELETE, "/orders/**").authenticated();
 
-                    // Showcases alternative endpoint protection via AMS route-level security
-                    // authz.requestMatchers(GET, "/products").access(via.checkPrivilege(READ_PRODUCTS));
-                    // authz.requestMatchers(GET, "/orders").access(via.precheckPrivilege(READ_ORDERS));
-                    // authz.requestMatchers(POST, "/orders").access(via.precheckPrivilege(CREATE_ORDERS));
-                    // authz.requestMatchers(DELETE, "/orders/**").access(via.checkPrivilege(DELETE_ORDERS));
+                    // Idiom 2 (route-level authorization + service-level filtering) Showcases alternative endpoint protection via AMS route-level security (+ service-level filtering)
+                    authz.requestMatchers(GET, "/products").access(via.checkPrivilege(READ_PRODUCTS));
+                    authz.requestMatchers(GET, "/orders").access(via.precheckPrivilege(READ_ORDERS));
+                    authz.requestMatchers(POST, "/orders").access(via.precheckPrivilege(CREATE_ORDERS));
+                    authz.requestMatchers(DELETE, "/orders/**").access(via.checkPrivilege(DELETE_ORDERS));
 
                     // Deny all other requests
                     authz.anyRequest().denyAll();


### PR DESCRIPTION
- Explicitly test `AmsRouteSecurity` for SB3/SB4 compatibility testing.
- Explicitly set `sap.ams.test.enabled = true` to override new `identity` binding based auto-configuration matcher in CAP sample which has mocked service bindings.
- Make `spring-boot-starter-cap-ams-test` compile-scoped instead of test-scoped to support `mvn spring-boot:run` with mock users