### PR TITLE
Bump dcl-compiler-plugin from 1.4.0 to 1.5.0

### DIFF
--- a/ams-cap-bookshop/pom.xml
+++ b/ams-cap-bookshop/pom.xml
@@ -22,7 +22,7 @@
         <cds.install-node.downloadUrl>https://nodejs.org/dist/</cds.install-node.downloadUrl>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sap.cloud.security.ams.version>4.4.1</sap.cloud.security.ams.version>
-        <sap.cloud.security.ams.dcl-compiler.version>1.4.0</sap.cloud.security.ams.dcl-compiler.version>
+        <sap.cloud.security.ams.dcl-compiler.version>1.5.0</sap.cloud.security.ams.dcl-compiler.version>
         <sap.cloud.security.version>4.0.8</sap.cloud.security.version>
     </properties>
 

--- a/ams-javalin-shopping/pom.xml
+++ b/ams-javalin-shopping/pom.xml
@@ -16,7 +16,7 @@
         <jdk.version>17</jdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sap.cloud.security.ams.version>4.4.1</sap.cloud.security.ams.version>
-        <sap.cloud.security.ams.dcl-compiler.version>1.4.0</sap.cloud.security.ams.dcl-compiler.version>
+        <sap.cloud.security.ams.dcl-compiler.version>1.5.0</sap.cloud.security.ams.dcl-compiler.version>
         <sap.cloud.environment.servicebinding.version>0.31.0</sap.cloud.environment.servicebinding.version>
         <javalin.version>7.2.2</javalin.version>
         <jackson.version>2.22.1</jackson.version>

--- a/ams-spring-boot-shopping/pom.xml
+++ b/ams-spring-boot-shopping/pom.xml
@@ -25,7 +25,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.boot.version>3.5.10</spring.boot.version>
         <sap.cloud.security.ams.version>4.4.1</sap.cloud.security.ams.version>
-        <sap.cloud.security.ams.dcl-compiler.version>1.4.0</sap.cloud.security.ams.dcl-compiler.version>
+        <sap.cloud.security.ams.dcl-compiler.version>1.5.0</sap.cloud.security.ams.dcl-compiler.version>
         <sap.cloud.security.version>4.0.8</sap.cloud.security.version>
         <sap.cloud.sdk.version>5.32.0</sap.cloud.sdk.version>
         <sap.cloud.environment.servicebinding.version>0.31.0</sap.cloud.environment.servicebinding.version>


### PR DESCRIPTION
Bumps `com.sap.cloud.security.ams.dcl:dcl-compiler-plugin` from **1.4.0** to **1.5.0** in all three samples:

- `ams-spring-boot-shopping`
- `ams-javalin-shopping`
- `ams-cap-bookshop`

## Verification

All three samples were built and tested locally with the new plugin version. Test counts unchanged, all green:

| Sample | Tests |
|---|---|
| ams-spring-boot-shopping | 12 |
| ams-javalin-shopping | 15 + 11 |
| ams-cap-bookshop | 3 + 9 + 7 + 12 |

Additionally, the generated DCN output (`target/generated-test-resources/ams/dcn/**`) was compared byte-for-byte against a 1.4.0 baseline for all three samples — no differences.